### PR TITLE
Update Sapphire Plus Configuration_adv.h

### DIFF
--- a/config/examples/Two Trees/Sapphire Plus/Sapphire Plus V2/Configuration_adv.h
+++ b/config/examples/Two Trees/Sapphire Plus/Sapphire Plus V2/Configuration_adv.h
@@ -1304,7 +1304,7 @@
 
   //#define BROWSE_MEDIA_ON_INSERT          // Open the file browser when media is inserted
 
-  #define EVENT_GCODE_SD_ABORT "G1 Z20\nG28XY"      // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
+  #define EVENT_GCODE_SD_ABORT "G28XY"      // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
 
   #if ENABLED(PRINTER_EVENT_LEDS)
     #define PE_LEDS_COMPLETED_TIME  (30*60) // (seconds) Time to keep the LED "done" color before restoring normal illumination


### PR DESCRIPTION
### Requirements
Sapphire Plus
Marlin bugfix-2.0.x

### Description


This change has the purpose of avoid the Bed from hitting the nozzle on Sapphire Plus when you Cancel/Stop while printing, bed should go away from the nozzle(down) and does the oposite.
Changed this line on configuration_adv.h (#define EVENT_GCODE_SD_ABORT "G28XY"), tested and works. 
.
### Benefits

This stops the bed from hitting the nozzle when you press Stop/Cancel while printing.

### Related Issues
